### PR TITLE
Prevents stack level too deep on inverse_of relations

### DIFF
--- a/lib/fe/extractor.rb
+++ b/lib/fe/extractor.rb
@@ -217,10 +217,11 @@ module Fe
       raise "This gem only knows how to extract stuff w ActiveRecord" unless record.kind_of? ActiveRecord::Base
       key = record.class.base_class.to_s # the base_class is key for correctly handling STI
       @output_hash[key] ||= Set.new # Set ensures no duplicates
+      return if @output_hash[key].include?(record) # Prevent infinite loops as association cache on record with inverse_of will cause this method to stack overflow
       @output_hash[key].add(record)
       record.association_cache.each_pair do |assoc_name,association_def|
         Array(association_def.target).each do |a|
-          self.recurse(a)
+          self.recurse(a)  
         end
       end
     end

--- a/spec/dummy_environments/sqlite/dummy1/models/post.rb
+++ b/spec/dummy_environments/sqlite/dummy1/models/post.rb
@@ -1,7 +1,7 @@
 require_relative './serialized_attribute_encoder'
 class Post < ActiveRecord::Base
   belongs_to :author
-  has_many :comments
+  has_many :comments, :inverse_of => :post
   attr_accessible :content, :name, :serialized_thing
   serialize :serialized_thing, SerializedAttributeEncoder.new
 end

--- a/test/models/comment.rb
+++ b/test/models/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ActiveRecord::Base
   belongs_to :author
-  belongs_to :post
+  belongs_to :post, :inverse_of => :comments
   attr_accessible :content
 end


### PR DESCRIPTION
When a relation is specified with an inverse_of the association_cache
will loop continuously between the parent and child records causing a
stack level too deep, this fix prevents this by checking for the
presence of the record in the output_hash first, added inverse of to
test models as well to test for this condition.  To reproduce the error simply comment out the change in extractor.rb and run the test.
