### PR TITLE
Add fact method for SDP usage

### DIFF
--- a/lib/fe.rb
+++ b/lib/fe.rb
@@ -47,6 +47,12 @@ module Fe
       extractor
     end
 
+    def fact(extract_name, key)
+      extractor = Fe::Extractor.new
+      extractor.name = extract_name
+      extractor.fact(key)
+    end
+
 
     # Used if you want to get a hash representation of a particular
     # fixture in a fixture set for a given model

--- a/lib/fe/extractor.rb
+++ b/lib/fe/extractor.rb
@@ -46,6 +46,11 @@ module Fe
       self.write_model_fixtures
     end
 
+    def fact(key)
+      manifest_hash = YAML.load_file(self.manifest_file_path)
+      manifest_hash.fetch(:fact_hash, {}).fetch(key)
+    end
+
     # Loads data from each fixture file in the extract set using
     # ActiveRecord::Fixtures
     #


### PR DESCRIPTION
The version of this gem that SDP uses is apparently custom. I can't
find it in either the public GitHub repo or the private enterprise one.
The one difference I see in SDPs version is that it supports the `fact`
method. You can write a test like

```
expect(x).to eq(Fe.fact(:fixture_name, :fact_attribute_name))
```

and in your fixture's manifest file you have

```
:fact_hash:
  :fact_attribute_name: 200
```

Then, when you run the test you can test that x is equal to 200

There is probably also code for extracting those facts, but I have not
ported that because I don't currently see a need. All I need is the
ability to pull those facts back out in my tests.