### PR TITLE
HABTM tables now extract all rows

### DIFF
--- a/lib/fe/extractor.rb
+++ b/lib/fe/extractor.rb
@@ -293,7 +293,11 @@ module Fe
           # below
           file.write records.inject({}) {|hash, record|
             # Array() bit done to support composite primary keys
-            fixture_name = "r#{Array(record.id).join('_')}"
+            if record.id.nil?
+              fixture_name = "r#{record.attributes.values.join('_')}"
+            else
+              fixture_name = "r#{Array(record.id).join('_')}"
+            end
             hash[fixture_name] = record.attributes
             # dump serialized attributes
             record.serialized_attributes.each do |attr, serializer|


### PR DESCRIPTION
This is not tested with odd primary key configurations but works fine with HABTM associations (creating a fixture_name out of the attributes' values).
